### PR TITLE
gamelist-cleaner.sh Fix for filenames with '&' not being removed

### DIFF
--- a/gamelist-cleaner.sh
+++ b/gamelist-cleaner.sh
@@ -201,9 +201,9 @@ for file in $gamelist_files; do
       original_gamelist="$backup_gamelist"
     fi
     
-    # use a temp file to convert "&" to "&amp: on the whole gamelist.xml even if the file has both "&" and "&amp;"
+    # use a temp file to convert &#39; to single quotes and "&" to "&amp: on the whole gamelist.xml even if the file has both "&" and "&amp;"
     temp_gamelist="/tmp/gamelist-$system.xml"
-    sed 's/\&/&amp;/g; s/;amp;/;/g' "$original_gamelist" > "$temp_gamelist"
+    sed "s/\&/&amp;/g; s/;amp;/;/g; s/&amp;#39;/'/g" "$original_gamelist" > "$temp_gamelist"
     original_gamelist=$(readlink -e "$temp_gamelist")
     cat "$original_gamelist" > "$clean_gamelist"
 


### PR DESCRIPTION
I have not tested this with other gamelists.xml but it worked with all of mine so maybe it can be of use.

I ran into another problem so It will first convert all of the \&amp; to & and then back to \&amp; just in case the gamelist has both in them e.g 

```Green & the blue where partying with yellow &amp; red``` 
will result in 
```Green &amp; the blue where partying with yellow &amp; red```

Then it will change \&amp; from filenames in \<path\> so that xmlstarlet finds the node

There might be a better way to do it, but hope you find it useful
